### PR TITLE
feat: specify mergers

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ github-actions-merger is github actions that merges pull request with commit mes
       "repo": ${{ github.event.repository.name }}
       "pr_number": ${{ github.event.issue.number }}
       "comment": ${{ github.event.comment.body }}
+      "mergers": 'na-ga,0daryo'
 ```
 https://github.com/abema/github-actions-merger/blob/main/.github/workflows/github-actions-merger.yaml
 
@@ -33,4 +34,5 @@ repo: ${{ github.event.repository.name }}
 pr_number: ${{ github.event.issue.number }}
 comment: ${{ github.event.comment.body }}
 merge_method: 'merge'
+mergers: 'comma separeted github usernames. every user is allowed if not specified'
 ```

--- a/action.yml
+++ b/action.yml
@@ -27,3 +27,6 @@ inputs:
   comment:
     description: 'pull comment'
     required: true
+  mergers:
+    description: 'github username who can trigger merger. every user is allowed if not specified. format must be comma separated .e.g. na-ga,0daryo'
+    required: false

--- a/main_test.go
+++ b/main_test.go
@@ -94,3 +94,54 @@ func Test_generateCommitSubject(t *testing.T) {
 		})
 	}
 }
+
+func Test_validateEnv(t *testing.T) {
+	type args struct {
+		e env
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "valid env",
+			args: args{
+				e: env{
+					Comment: "/merge",
+					Mergers: []string{"0daryo"},
+					Actor:   "0daryo",
+				},
+			},
+		},
+		{
+			name: "invalid comment",
+			args: args{
+				e: env{
+					Comment: "/approve",
+					Mergers: []string{"0daryo"},
+					Actor:   "0daryo",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "actor is not merger",
+			args: args{
+				e: env{
+					Comment: "/approve",
+					Mergers: []string{"0daryo"},
+					Actor:   "github",
+				},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := validateEnv(tt.args.e); (err != nil) != tt.wantErr {
+				t.Errorf("validateEnv() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -129,7 +129,7 @@ func Test_validateEnv(t *testing.T) {
 			name: "actor is not merger",
 			args: args{
 				e: env{
-					Comment: "/approve",
+					Comment: "/merge",
 					Mergers: []string{"0daryo"},
 					Actor:   "github",
 				},


### PR DESCRIPTION
## Summary
- Add input value ```mergers```
Restrict who can use this workflow.
Note: Input value is comma separeted usernames, bacause github inputs supports only strings.
https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#inputs