### PR TITLE
fix: Invalid branding icon

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -2,7 +2,7 @@ name: 'github-actions-merger'
 description: 'merge pull request with labels'
 author: 'abema'
 branding:
-  icon: 'meh'
+  icon: 'git-merge'
   color: 'green'
 runs:
   using: 'docker'


### PR DESCRIPTION
## References

- [Metadata syntax for GitHub Actions - GitHub Docs](https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#branding)
- https://feathericons.com/?query=git-merge