### PR TITLE
fix: change image for Dockerfile (distroless -> alpine)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY *.go ./
 RUN apk --no-cache add --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community github-cli=2.32.0-r1
 RUN CGO_ENABLED=0 GOOS=linux go build -a -o /bin/app
 
-FROM gcr.io/distroless/static
+FROM alpine:3.18.2
 COPY --from=builder /bin/app /bin/app
 COPY --from=builder /usr/bin/gh /bin/gh
 ENTRYPOINT ["/bin/app"]


### PR DESCRIPTION
I could not execute the copied gh command with distroless, so I changed the image to alpine.